### PR TITLE
Add configuration for Chainguard Enforce

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,10 @@
+---
+spec:
+  authorities:
+    # Accept all keyless signatures validated from the public sigstore instance.
+    # This is open source software after all. All we want to know is that the
+    # person that did the commit has control over their email address.
+    - keyless: {}
+    # Add this if you also want to allow commits signed by GitHub.
+    - key:
+        kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
This adds a configuration for Enforce that will accept publicly
verifiable commits from `sigstore.dev` as well as the GPG key from
GitHub Apps.

Enforce already enabled, so remember to [install
`gitsign`](https://github.com/sigstore/gitsign)
and enable it for this repository as follows:

```bash
cd /path/to/my/repository
git config --local commit.gpgsign true  # Sign all commits
git config --local tag.gpgsign true  # Sign all tags
git config --local gpg.x509.program gitsign  # Use gitsign for signing
git config --local gpg.format x509  # gitsign expects x509 args
```

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
